### PR TITLE
Reinstate urbica

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.obj
 *.pbf
 *.zip
-
+.DS_Store
 graphs/
 osmconvert*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Stepan Kuzmin <to.stepan.kuzmin@gmail.com>"
 ENV OTP_VERSION=1.4.0
 ENV JAVA_OPTIONS=-Xmx1G
 
-ADD http://central.maven.org/maven2/org/opentripplanner/otp/$OTP_VERSION/otp-$OTP_VERSION-shaded.jar /usr/local/share/java/
+ADD https://repo1.maven.org/maven2/org/opentripplanner/otp/$OTP_VERSION/otp-$OTP_VERSION-shaded.jar /usr/local/share/java/
 
 RUN ln -s otp-$OTP_VERSION-shaded.jar /usr/local/share/java/otp.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java11-alpine:11.0
+FROM adoptopenjdk/openjdk11:jre-11.0.13_8-alpine
 LABEL authors="Stepan Kuzmin <to.stepan.kuzmin@gmail.com>, Sandeep Pandey <spandey.ike@gmail.com, Tariq Baig-Meininghaus tarbaig@gmail.com"
 
 ENV OTP_VERSION=2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM lpicanco/java11-alpine:11.0
-LABEL authors="Stepan Kuzmin <to.stepan.kuzmin@gmail.com>, Sandeep Pandey <spandey.ike@gmail.com"
+FROM java11-alpine:11.0
+LABEL authors="Stepan Kuzmin <to.stepan.kuzmin@gmail.com>, Sandeep Pandey <spandey.ike@gmail.com, Tariq Baig-Meininghaus tarbaig@gmail.com"
 
 ENV OTP_VERSION=2.0.0
 ENV JAVA_OPTIONS=-Xmx2G

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM java:8-alpine
-LABEL maintainer="Stepan Kuzmin <to.stepan.kuzmin@gmail.com>"
+FROM lpicanco/java11-alpine:11.0
+LABEL authors="Stepan Kuzmin <to.stepan.kuzmin@gmail.com>, Sandeep Pandey <spandey.ike@gmail.com"
 
-ENV OTP_VERSION=1.4.0
-ENV JAVA_OPTIONS=-Xmx1G
+ENV OTP_VERSION=2.0.0
+ENV JAVA_OPTIONS=-Xmx2G
 
 ADD https://repo1.maven.org/maven2/org/opentripplanner/otp/$OTP_VERSION/otp-$OTP_VERSION-shaded.jar /usr/local/share/java/
 

--- a/README.md
+++ b/README.md
@@ -4,49 +4,52 @@
 
 ## Usage
 
+Build the docker image from the Dockerfile:
+
+```shell
+docker build -t my_docker_id/otp .
+```
+
 Build graphs using GTFS and OSM extract in the current directory:
 
 ```shell
 docker run \
-  -v $PWD:/graphs \
-  -e JAVA_OPTIONS=-Xmx4G \
-  urbica/otp --build /graphs
+-v $PWD/graphs:/var/otp/graphs \
+-e JAVA_OPTIONS=-Xmx4G \
+my_docker_id/otp --build \
+--save /var/otp/graphs/city_name
 ```
 
-Run OTP server:
+Run OTP server by loading the graph, and exposing OTP's port 8080 to our machine's port 8080:
 
 ```shell
 docker run \
   -p 8080:8080 \
-  -v $PWD:/var/otp/graphs \
+  -v $PWD/graphs:/var/otp/graphs \
   -e JAVA_OPTIONS=-Xmx4G \
-  otp --server --autoScan --verbose
+  my_docker_id/otp --load /var/otp/graphs/city_name/
 ```
 
-...or run OTP server with analyst module:
-
-```shell
-docker run \
-  -p 8080:8080 \
-  -v $PWD:/graphs \
-  -e JAVA_OPTIONS=-Xmx4G \
-  urbica/otp --basePath /data --server --analyst --autoScan --verbose
-```
+It seems [Analyst API ](https://docs.opentripplanner.org/en/latest/OTP2-MigrationGuide/#analyst "Analyst API ")have been removed in this version.
 
 ## Basic Tutorial
 
-Based on [OpenTripPlanner Basic Tutorial](https://opentripplanner.readthedocs.io/en/latest/Basic-Tutorial/).
+Based on [OpenTripPlanner Basic Tutorial](https://docs.opentripplanner.org/en/latest/Basic-Tutorial/).
 
 ### Get some data
-
-Get GTFS for Transit Schedules and Stops
+Clone this repo to your machine.
+```shell
+git clone https://github.com/ikespand/docker-otp
+cd docker-otp
+```
+Get GTFS for Transit Schedules and Stops (As a sample for Portland),
 
 ```shell
 mkdir -p ./graphs/portland
 wget "http://developer.trimet.org/schedule/gtfs.zip" -O ./graphs/portland/trimet.gtfs.zip
 ```
 
-Get OSM extract for Streets
+Get OpenStreetMap extract for the streets. osmconvert step is used to reduce the data size, you can skip this step if you've allocated sufficient memory to your docker. Otherwise [download](hthttps://wiki.openstreetmap.org/wiki/Osmconvert#Binariestp:// "download") osmconvert.
 
 ```shell
 wget http://download.geofabrik.de/north-america/us/oregon-latest.osm.pbf
@@ -56,30 +59,41 @@ mv portland.pbf ./graphs/portland
 
 ### Start up OTP
 
-Build graph
+Build the docker image from the Dockerfile:
+
+```shell
+docker build -t ikespand/otp .
+```
+
+Build graphs using GTFS and OSM extract in the current directory:
 
 ```shell
 docker run \
-  -v $PWD/graphs:/var/otp/graphs \
-  -e JAVA_OPTIONS=-Xmx4G \
-  urbica/otp --build /var/otp/graphs/portland
+ -v $PWD/graphs:/var/otp/graphs \
+ -e JAVA_OPTIONS=-Xmx4G \
+ ikespand/otp --build \
+ --save /var/otp/graphs/portland
 ```
 
-Run OTP server:
+Run OTP server by loading the graph, and exposing OTP's port 8080 to our machine's port 8080:
 
 ```shell
 docker run \
   -p 8080:8080 \
   -v $PWD/graphs:/var/otp/graphs \
   -e JAVA_OPTIONS=-Xmx4G \
-  urbica/otp --server --autoScan --verbose
+  ikespand/otp --load /var/otp/graphs/portland
 ```
 
+Alternatively, modify the `docker-compose.yml` and then execute:
+```shell
+docker-compose up
+```
 The graph build operation should take about one minute to complete, and then you'll see a Grizzly server running message. At this point you have an OpenTripPlanner server running locally and can open http://localhost:8080/ in a web browser. You should be presented with a web client that will interact with your local OpenTripPlanner instance.
 
 This map-based user interface is in fact sending HTTP GET requests to the OTP server running on your local machine. It can be informative to watch the HTTP requests and responses being generated using the developer tools in your web browser.
 
-### Usage
+### Resources
 
 There are a number of different resources available through the HTTP API. Besides trip planning, OTP can also look up information about transit routes and stops from the GTFS you loaded and return this information as JSON. For example:
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,13 @@
 
 ## Usage
 
-Build the docker image from the Dockerfile:
-
-```shell
-docker build -t my_docker_id/otp .
-```
-
 Build graphs using GTFS and OSM extract in the current directory:
 
 ```shell
 docker run \
 -v $PWD/graphs:/var/otp/graphs \
 -e JAVA_OPTIONS=-Xmx4G \
-my_docker_id/otp --build \
+urbica/otp --build \
 --save /var/otp/graphs/city_name
 ```
 
@@ -27,7 +21,7 @@ docker run \
   -p 8080:8080 \
   -v $PWD/graphs:/var/otp/graphs \
   -e JAVA_OPTIONS=-Xmx4G \
-  my_docker_id/otp --load /var/otp/graphs/city_name/
+  urbica/otp --load /var/otp/graphs/city_name/
 ```
 
 It seems [Analyst API ](https://docs.opentripplanner.org/en/latest/OTP2-MigrationGuide/#analyst "Analyst API ")have been removed in this version.
@@ -37,11 +31,6 @@ It seems [Analyst API ](https://docs.opentripplanner.org/en/latest/OTP2-Migratio
 Based on [OpenTripPlanner Basic Tutorial](https://docs.opentripplanner.org/en/latest/Basic-Tutorial/).
 
 ### Get some data
-Clone this repo to your machine.
-```shell
-git clone https://github.com/ikespand/docker-otp
-cd docker-otp
-```
 Get GTFS for Transit Schedules and Stops (As a sample for Portland),
 
 ```shell
@@ -59,11 +48,7 @@ mv portland.pbf ./graphs/portland
 
 ### Start up OTP
 
-Build the docker image from the Dockerfile:
 
-```shell
-docker build -t ikespand/otp .
-```
 
 Build graphs using GTFS and OSM extract in the current directory:
 
@@ -71,7 +56,7 @@ Build graphs using GTFS and OSM extract in the current directory:
 docker run \
  -v $PWD/graphs:/var/otp/graphs \
  -e JAVA_OPTIONS=-Xmx4G \
- ikespand/otp --build \
+ urbica/otp --build \
  --save /var/otp/graphs/portland
 ```
 
@@ -82,7 +67,7 @@ docker run \
   -p 8080:8080 \
   -v $PWD/graphs:/var/otp/graphs \
   -e JAVA_OPTIONS=-Xmx4G \
-  ikespand/otp --load /var/otp/graphs/portland
+  urbica/otp --load /var/otp/graphs/portland
 ```
 
 Alternatively, modify the `docker-compose.yml` and then execute:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,17 @@
-version: '3.7'
+version: '2.0'
 
 services:
   otp:
-    image: otp
+    image: ikespand/otp
     restart: unless-stopped
     ports:
       - 8080:8080
     volumes:
       - ./graphs:/var/otp/graphs
     environment:
-      - JAVA_OPTIONS=-Xmx8G
+      - JAVA_OPTIONS=-Xmx2G
     command:
       [
-        '--server',
-        '--maxThreads 4',
-        '--analyst',
-        '--autoScan',
-        '--insecure',
-        '--verbose',
+        '--load /var/otp/graphs/stuttgart',
+        '--maxThreads 4'
       ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.0'
 
 services:
   otp:
-    image: urbica/otp
+    image:  urbica/otp
     restart: unless-stopped
     ports:
       - 8080:8080
@@ -12,6 +12,6 @@ services:
       - JAVA_OPTIONS=-Xmx2G
     command:
       [
-        '--load /var/otp/graphs/stuttgart',
+        '--load /var/otp/graphs/portland',
         '--maxThreads 4'
       ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.0'
 
 services:
   otp:
-    image: ikespand/otp
+    image: urbica/otp
     restart: unless-stopped
     ports:
       - 8080:8080


### PR DESCRIPTION
I modified the points criticised in #2. Most notably I changed the base image of to ```adoptopenjdk/openjdk11:jre-11.0.13_8-alpine```. This is needed since opt 2 does not work under java 8. 

Since there are some incompatibilities between opt1 and 2 it might make sense to put otp2 into a separate branch.